### PR TITLE
library versioning and automatic object destructor call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,17 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5.1)
 project(bbblueeeros)
 
-## Compiler flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_STANDARD 14)
+
+## fetch the version information from git ; Source: https://github.com/Munkei/munkei-cmake
+## doc: https://github.com/Munkei/munkei-cmake/blob/master/doc/MunkeiVersionFromGit.md
+include(cmake/MunkeiVersionFromGit.cmake)
+version_from_git()
 
 include_directories(${ADDITIONAL_INCLUDE_DIRS})
 link_directories(${ADDITIONAL_LINK_DIRS})
 
-find_package(EEROS REQUIRED)
+find_package(EEROS ${REQUIRED_EEROS_VERSION} REQUIRED)
 include_directories(${EEROS_INCLUDE_DIR})
 link_directories(${EEROS_LIB_DIR})
 

--- a/cmake/MunkeiVersionFromGit.cmake
+++ b/cmake/MunkeiVersionFromGit.cmake
@@ -1,0 +1,167 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2017 Theo Willows
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required( VERSION 3.0.0 )
+
+include( CMakeParseArguments )
+
+function( version_from_git )
+  # Parse arguments
+  set( options OPTIONAL FAST )
+  set( oneValueArgs
+    GIT_EXECUTABLE
+    INCLUDE_HASH
+    LOG
+    TIMESTAMP
+    )
+  set( multiValueArgs )
+  cmake_parse_arguments( ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+  # Defaults
+  if( NOT DEFINED ARG_INCLUDE_HASH )
+    set( ARG_INCLUDE_HASH ON )
+  endif()
+
+  if( DEFINED ARG_GIT_EXECUTABLE )
+    set( GIT_EXECUTABLE "${ARG_GIT_EXECUTABLE}" )
+  else ()
+    # Find Git or bail out
+    find_package( Git )
+    if( NOT GIT_FOUND )
+      message( FATAL_ERROR "[MunkeiVersionFromGit] Git not found" )
+    endif( NOT GIT_FOUND )
+  endif()
+
+  # Git describe
+  execute_process(
+    COMMAND           "${GIT_EXECUTABLE}" describe --tags
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    RESULT_VARIABLE   git_result
+    OUTPUT_VARIABLE   git_describe
+    ERROR_VARIABLE    git_error
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+    )
+  if( NOT git_result EQUAL 0 )
+    message( FATAL_ERROR
+      "[MunkeiVersionFromGit] Failed to execute Git: ${git_error}"
+      )
+  endif()
+
+  # Get Git tag
+  execute_process(
+    COMMAND           "${GIT_EXECUTABLE}" describe --tags --abbrev=0
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    RESULT_VARIABLE   git_result
+    OUTPUT_VARIABLE   git_tag
+    ERROR_VARIABLE    git_error
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+    )
+  if( NOT git_result EQUAL 0 )
+    message( FATAL_ERROR
+      "[MunkeiVersionFromGit] Failed to execute Git: ${git_error}"
+      )
+  endif()
+
+  if( git_tag MATCHES "^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)(-[.0-9A-Za-z-]+)?([+][.0-9A-Za-z-]+)?$" )
+    set( version_major "${CMAKE_MATCH_1}" )
+    set( version_minor "${CMAKE_MATCH_2}" )
+    set( version_patch "${CMAKE_MATCH_3}" )
+    set( identifiers   "${CMAKE_MATCH_4}" )
+    set( metadata      "${CMAKE_MATCH_5}" )
+  else()
+    message( FATAL_ERROR
+      "[MunkeiVersionFromGit] Git tag isn't valid semantic version: [${git_tag}]"
+      )
+  endif()
+
+  if( "${git_tag}" STREQUAL "${git_describe}" )
+    set( git_at_a_tag ON )
+  endif()
+
+  if( NOT git_at_a_tag )
+    # Extract the Git hash (if one exists)
+    string( REGEX MATCH "g[0-9a-f]+$" git_hash "${git_describe}" )
+  endif()
+
+  # Construct the version variables
+  set( version ${version_major}.${version_minor}.${version_patch} )
+  set( semver  ${version} )
+
+  # Identifiers
+  if( identifiers MATCHES ".+" )
+    string( SUBSTRING "${identifiers}" 1 -1 identifiers )
+    set( semver "${semver}-${identifiers}")
+  endif()
+
+  # Metadata
+  # TODO Split and join (add Git hash inbetween)
+  if( metadata MATCHES ".+" )
+    string( SUBSTRING "${metadata}" 1 -1 metadata )
+    # Split
+    string( REPLACE "." ";" metadata "${metadata}" )
+  endif()
+
+  if( NOT git_at_a_tag )
+
+    if( ARG_INCLUDE_HASH )
+      list( APPEND metadata "${git_hash}" )
+    endif( ARG_INCLUDE_HASH )
+
+    # Timestamp
+    if( DEFINED ARG_TIMESTAMP )
+      string( TIMESTAMP timestamp "${ARG_TIMESTAMP}" ${ARG_UTC} )
+      list( APPEND metadata "${timestamp}" )
+    endif( DEFINED ARG_TIMESTAMP )
+
+  endif()
+
+  # Join
+  string( REPLACE ";" "." metadata "${metadata}" )
+
+  if( metadata MATCHES ".+" )
+    set( semver "${semver}+${metadata}")
+  endif()
+
+  # Log the results
+  if( ARG_LOG )
+    message( STATUS
+      "[MunkeiVersionFromGit] Version: ${version}
+     Git tag:     [${git_tag}]
+     Git hash:    [${git_hash}]
+     Decorated:   [${git_describe}]
+     Identifiers: [${identifiers}]
+     Metadata:    [${metadata}]
+     SemVer:      [${semver}]"
+      )
+  endif( ARG_LOG )
+
+  # Set parent scope variables
+  set( GIT_TAG       ${git_tag}       PARENT_SCOPE )
+  set( SEMVER        ${semver}        PARENT_SCOPE )
+  set( VERSION       ${version}       PARENT_SCOPE )
+  set( VERSION_MAJOR ${version_major} PARENT_SCOPE )
+  set( VERSION_MINOR ${version_minor} PARENT_SCOPE )
+  set( VERSION_PATCH ${version_patch} PARENT_SCOPE )
+
+endfunction( version_from_git )

--- a/include/BBBlueDevice.hpp
+++ b/include/BBBlueDevice.hpp
@@ -6,9 +6,6 @@ namespace bbblue {
 	public:
 		BBBlueDevice();
 		virtual ~BBBlueDevice();
-		
-	private:
-		static BBBlueDevice* instance;
 	};
 };
 

--- a/lib/BBBlueDevice.cpp
+++ b/lib/BBBlueDevice.cpp
@@ -2,6 +2,8 @@
 #include <eeros/core/Fault.hpp>
 #include <iostream>
 
+#include <memory>
+
 extern "C" {
 #include <rc_usefulincludes.h>
 #include <roboticscape.h>
@@ -21,6 +23,7 @@ BBBlueDevice::BBBlueDevice() {
 
 BBBlueDevice::~BBBlueDevice() {
 	rc_cleanup();
+	std::cout << "robotics cape cleaned up." << std::endl;
 }
 
-BBBlueDevice* BBBlueDevice::instance = new BBBlueDevice();
+std::unique_ptr<BBBlueDevice> instance{new BBBlueDevice()};

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -8,4 +8,6 @@ add_library(bbblueeeros SHARED ${BBBLUEEEROS_SRCS})
 target_link_libraries(bbblueeeros roboticscape eeros)
 # target_link_libraries(bbblueeeros_static roboticscape eeros)
 
-INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/libbbblueeeros.so DESTINATION lib)
+set_target_properties(bbblueeeros PROPERTIES VERSION ${VERSION})
+
+INSTALL(TARGETS bbblueeeros LIBRARY DESTINATION lib)


### PR DESCRIPTION
## Changes
* change CMakeLists so cmake it will fetch library version info from git tag.
* change CMakeLists so cmake requires specific EEROS version specified in variable *REQUIRED_EEROS_VERSION*
* change pointer member variable to global std::unique_ptr variable. This ensures that object is destructed when module is unloaded when application is terminated.

## Issues
* This changes will cause problems when *REQUIRED_EEROS_VERSION* variable is not set by the one who is executing cmake build. (This is considered in https://github.com/ntb-ch/BeagleBoneBlue)
* EEROS shared library must be available in specified version or the build will fail.
* This git repository must contain at least one tag in the form **v0.1.0**